### PR TITLE
import weight_init class for LastLevelP6

### DIFF
--- a/swint/swin_transformer.py
+++ b/swint/swin_transformer.py
@@ -7,7 +7,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
+
 import numpy as np
+import fvcore.nn.weight_init as weight_init
 from timm.models.layers import DropPath, to_2tuple, trunc_normal_
 
 from detectron2.modeling.backbone import Backbone


### PR DESCRIPTION
`weight_init.c2_xavier_fill` is not available without importing the `weight_init` class from `fvcore.nn.weight_init`.